### PR TITLE
[1.9] Use default timezone instead of deprecated server timezone

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.3.0 (Unreleased)
+---------------------
+- Enh: Use default timezone instead of deprecated server timezone
+
 v1.2.1 (Unreleased)
 ----------------------
 - Fix #100: Remove unnecessary migration that removed module folder on first enabling

--- a/models/ExternalCalendarEntry.php
+++ b/models/ExternalCalendarEntry.php
@@ -442,7 +442,7 @@ class ExternalCalendarEntry extends ContentActiveRecord implements Searchable
     public function generateIcs()
     {
         $module = Yii::$app;
-        $timezone = $module->settings->get('timeZone');
+        $timezone = $module->settings->get('defaultTimeZone');
         $ics = new ICS($this->title, $this->description, $this->start_datetime, $this->end_datetime, $this->location, null, $timezone, $this->all_day);
         return $ics;
     }

--- a/module.json
+++ b/module.json
@@ -6,9 +6,9 @@
     "calendar",
     "external calendar"
   ],
-  "version": "1.2.1",
+  "version": "1.3.0",
   "humhub": {
-    "minVersion": "1.7"
+    "minVersion": "1.9"
   },
   "screenshots": [
     "assets/screen1.jpg",


### PR DESCRIPTION
Issue: https://github.com/humhub/humhub/issues/4871#issuecomment-810920095

Min HumHub version 1.9 is required.