### PR TITLE
Fixed missing offset from daylight savings time

### DIFF
--- a/integration/calendar/CalendarExportService.php
+++ b/integration/calendar/CalendarExportService.php
@@ -52,7 +52,7 @@ class CalendarExportService extends BaseObject
                 $items[] = $this->calendarService->getCalendarItems($from, $to, $export->getFilterArray(), $container, null, false);
             }
 
-            $cal = VCalendar::withEvents(array_merge(...$items));
+            $cal = VCalendar::withEvents(array_merge(...$items), "Europe/Berlin"));
 
             return $cal->serialize();
         } finally {


### PR DESCRIPTION
When the humhub calender is imported into outlook for windows, all entries that are defined after the 27th of march (change from standard time to daylight savings time) are off by +1 hour.

Our quick fix was, to hard code the timezone into the withEvents() method of VCalendar, so that the correct header is added to the exported ics.