### PR TITLE
Fix: Unable to delete space external calendars

### DIFF
--- a/controllers/CalendarController.php
+++ b/controllers/CalendarController.php
@@ -138,7 +138,7 @@ class CalendarController extends ContentContainerController
      */
     public function actionDelete($id)
     {
-        $this->findModel($id)->delete();
+        $this->findModel($id)->hardDelete();
         $this->view->success(Yii::t('ExternalCalendarModule.results', 'Calendar successfully deleted!'));
         return $this->redirect($this->contentContainer->createUrl('index'));
     }


### PR DESCRIPTION
Fixes not being able to delete external calendars for spaces in HumHub v1.15.x