### PR TITLE
Make URL location clickable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+TBA
+- Enh #68: Make URL locations clickable
+
 1.4.2 (January 19, 2023)
 -----------------------
 - Enh #57: Tests for `next` version

--- a/models/ExternalCalendarEntry.php
+++ b/models/ExternalCalendarEntry.php
@@ -14,7 +14,7 @@ use humhub\modules\external_calendar\widgets\WallEntry;
 use humhub\modules\external_calendar\helpers\CalendarUtils;
 use DateTimeZone;
 use humhub\libs\Html;
-use humhub\libs\Button;
+use humhub\widgets\Button;
 use humhub\modules\search\interfaces\Searchable;
 use ICal\Event;
 use humhub\modules\external_calendar\models\forms\ConfigForm;

--- a/models/ExternalCalendarEntry.php
+++ b/models/ExternalCalendarEntry.php
@@ -14,6 +14,7 @@ use humhub\modules\external_calendar\widgets\WallEntry;
 use humhub\modules\external_calendar\helpers\CalendarUtils;
 use DateTimeZone;
 use humhub\libs\Html;
+use humhub\libs\Button;
 use humhub\modules\search\interfaces\Searchable;
 use ICal\Event;
 use humhub\modules\external_calendar\models\forms\ConfigForm;
@@ -550,5 +551,24 @@ class ExternalCalendarEntry extends ContentActiveRecord implements Searchable
         }
 
         return !$this->last_modified || CalendarUtils::formatDateTimeToAppTime($icalEvent->getLastModified()) > $this->getLastModifiedDateTime();
+    }
+
+     /**
+     * Get location of this external calendar entry
+     *
+     * @return string
+     */
+    public function getLocation(bool $asHtml = false)
+    {
+        if (!$asHtml) {
+            return $this->location;
+        }
+        if (
+            filter_var($this->location, FILTER_VALIDATE_URL) !== false
+            && strpos($this->location, 'https://') === 0 // restrict to secure URLs (and not HTTP, SSF, FTP, etc.)
+        ) {
+            return Button::asLink($this->location)->link($this->location)->options(['target' => '_blank']);
+        }
+        return Html::encode($this->location);
     }
 }

--- a/widgets/views/wallEntry.php
+++ b/widgets/views/wallEntry.php
@@ -29,7 +29,7 @@ $descriptionParser->enableNewlines = true;
         <?php if (!empty($calendarEntry->location)) : ?>
             <p>
                 <?= Icon::get('map-marker ')->color($color)->size(Icon::SIZE_LG)->fixedWith(true)->style('margin-top:2px') ?>
-                <?= Html::encode($calendarEntry->location) ?>
+                <?= $calendarEntry->getLocation(true) ?>
             </p>
         <?php endif; ?>
 


### PR DESCRIPTION
If a location is a https link the Calendar modules shows it as link.
With this PR it works the same for imported events.
The code is copied from the calendar module.

- [x] changelog