### PR TITLE
Add Space::USERGROUP_GUEST to fixed permissions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 - Enh #79: Replace theme variables with CSS variables
 - Enh #81: Use PHP CS Fixer
 - Enh #82: Reduce translation message categories
+- Enh #83: Add Space::USERGROUP_GUEST to fixed permissions
 
 1.4.2 (January 19, 2023)
 -----------------------

--- a/permissions/ManageCalendar.php
+++ b/permissions/ManageCalendar.php
@@ -34,10 +34,10 @@ class ManageCalendar extends BasePermission
      */
     protected $fixedGroups = [
         Space::USERGROUP_USER,
+        Space::USERGROUP_GUEST,
         User::USERGROUP_FRIEND,
         User::USERGROUP_GUEST,
         User::USERGROUP_USER,
-        User::USERGROUP_FRIEND,
     ];
 
 

--- a/permissions/ManageEntry.php
+++ b/permissions/ManageEntry.php
@@ -34,10 +34,10 @@ class ManageEntry extends BasePermission
      */
     protected $fixedGroups = [
         Space::USERGROUP_USER,
+        Space::USERGROUP_GUEST,
         User::USERGROUP_FRIEND,
         User::USERGROUP_GUEST,
         User::USERGROUP_USER,
-        User::USERGROUP_FRIEND,
     ];
 
 


### PR DESCRIPTION
Guests should never edit external calendars or entries, so showing this permission setting is confusing. I guess it was just forgotten.
I also removed the double mentioning of 'User::USERGROUP_FRIEND'